### PR TITLE
Remove final keyword from Item DTO to allow extension

### DIFF
--- a/src/DTO/Properties/Item.php
+++ b/src/DTO/Properties/Item.php
@@ -9,7 +9,7 @@ use Sylius\Component\Core\Model\OrderItemInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Webmozart\Assert\Assert;
 
-final class Item extends Base
+class Item extends Base
 {
     use MoneyFormatterTrait;
 


### PR DESCRIPTION
All other DTO are not final, and it makes sense if you want to extend them (with extra steps, but that's for another PR :smile: )